### PR TITLE
fix: cookies not accepting expiry date for removal

### DIFF
--- a/YOUR_ADMIN/includes/auto_loaders/config.savecart_admin.php
+++ b/YOUR_ADMIN/includes/auto_loaders/config.savecart_admin.php
@@ -4,7 +4,7 @@
 //
 // Copyright (c) 2021, Vinos de Frutas Tropicales (lat9)
 //
-$autoLoadConfig[200][] = array(
+$autoLoadConfig[200][] = [
     'autoType' => 'init_script',
     'loadFile' => 'init_savecart_admin.php'
-);
+];

--- a/includes/auto_loaders/config.savecart.php
+++ b/includes/auto_loaders/config.savecart.php
@@ -17,6 +17,5 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-$autoLoadConfig[90][] = array('autoType'=>'class', 'loadFile'=>'observers/class.savecart.php');
-$autoLoadConfig[90][] = array('autoType'=>'classInstantiate','className'=>'save_cart','objectName'=>'save_cart');
-?>
+$autoLoadConfig[90][] = ['autoType'=>'class', 'loadFile'=>'observers/class.savecart.php'];
+$autoLoadConfig[90][] = ['autoType'=>'classInstantiate','className'=>'save_cart','objectName'=>'save_cart'];

--- a/includes/classes/observers/class.savecart.php
+++ b/includes/classes/observers/class.savecart.php
@@ -184,7 +184,7 @@ class save_cart extends base
      * @param $eventID
      * @return void
      */
-    public function update(&$class, $eventID)
+    public function update(&$class, $eventID): void
     {
         switch ($eventID) {
             case 'NOTIFIER_CART_ADD_CART_END':        // on adding a product to the cart
@@ -215,7 +215,7 @@ class save_cart extends base
     /**
      * @return void
      */
-    protected function expireKeepCartCookie()
+    protected function expireKeepCartCookie(): void
     {
         $this->cookie_options['expires'] = time() - 3600;
         setcookie('cart', '', $this->cookie_options);

--- a/includes/classes/observers/class.savecart.php
+++ b/includes/classes/observers/class.savecart.php
@@ -104,13 +104,13 @@ class save_cart extends base
                         // First, check to see that the base product is still present and not disabled.  If so, the
                         // product will be removed from the customer's shopping-cart.
                         //
-                        $prid = zen_get_prid($products_id);
+                        $prid = (int)$products_id;//$products_id will be an integer if no atttributes (avoid zen_get_prid which is hinted as string)
                         $status_info = $db->Execute(
-                            "SELECT products_status
-                               FROM " . TABLE_PRODUCTS . "
-                              WHERE products_id = " . (int)$prid . "
+                            'SELECT products_status
+                               FROM ' . TABLE_PRODUCTS . '
+                              WHERE products_id = ' . $prid . '
                                 AND products_status != 0
-                              LIMIT 1"
+                              LIMIT 1'
                         );
                         if ($status_info->EOF) {
                             unset($_SESSION['cart']->contents[$products_id]);
@@ -127,7 +127,7 @@ class save_cart extends base
                         //
                         if (isset($details['attributes'])) {
                             $attributes_ok = true;
-                            $language_id = (isset($_SESSION['languages_id'])) ? $_SESSION['languages_id'] : 1;
+                            $language_id = (isset($_SESSION['languages_id'])) ? (int)$_SESSION['languages_id'] : 1;
                             foreach ($details['attributes'] as $options_id => $options_values_id) {
                                 $attr_check = $db->Execute(
                                     "SELECT pa.products_attributes_id


### PR DESCRIPTION
On a cleanup I found I had both keep_cart and save_cart in the mix....I suggest that all references in this plugin be renamed to keep_cart at some point.

Meanwhile both were disabled. So when enabled. I found the cookies were not being expired....so on deletion of a product or quantity change 1->0, the cart remained at 1.

I found that it was necessary to provide the identical domain and path info as well as the expiry time, to get it to delete.
I've made the cookie options a variable so it's accessible by the set and remove code.

Also some fettling....